### PR TITLE
Fixed invalid list indices on Arris PW of day

### DIFF
--- a/modules/misc/arris/tm602a_password_day.py
+++ b/modules/misc/arris/tm602a_password_day.py
@@ -113,7 +113,7 @@ class Misc(core.Misc.RextMisc):
             for i in range(10):
                 list4[i] = list3[table2[num8][i]]
             for i in range(10):
-                list5[i] = (ord(seed[i]) + list4[i]) % 36
+                list5[i] = int((ord(seed[i]) + list4[i]) % 36)
 
             password_list = [""]*10
             for i in range(10):


### PR DESCRIPTION
Before the fix:

$ python pwod.py 
Traceback (most recent call last):
  File "pwod_injection.py", line 89, in <module>
    password = generate_arris_password(start_date, end_date)
  File "pwod_injection.py", line 70, in generate_arris_password
    password_list[i] = alphanum[list5[i]]
TypeError: list indices must be integers, not float

After the fix:

$ python pwod_injection.py 
ZOU3MVLZLX